### PR TITLE
Remove mail flush queue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "require": {
         "php": ">=5.4.4",
         "symfony/symfony": ">=2.1",
+        "symfony/swiftmailer-bundle": ">=2.3.5",
         "doctrine/orm": ">=2.1.3",
         "monolog/monolog": ">=1.1.0",
         "swiftmailer/swiftmailer": ">=4.1.3"


### PR DESCRIPTION
Remove mail flush queue : the flush is now triggered on Console::TERMINATE event (since swiftmailer-bundle 2.3.5)
