### PR TITLE
Configure a step element configuration value via its setter 

### DIFF
--- a/Item/AbstractConfigurableStepElement.php
+++ b/Item/AbstractConfigurableStepElement.php
@@ -3,6 +3,7 @@
 namespace Akeneo\Bundle\BatchBundle\Item;
 
 use Doctrine\Common\Util\Inflector;
+use Symfony\Component\PropertyAccess\PropertyAccess;
 
 /**
  * Define a configurable step element
@@ -58,9 +59,11 @@ abstract class AbstractConfigurableStepElement
      */
     public function setConfiguration(array $config)
     {
+        $accessor = PropertyAccess::createPropertyAccessor();
+
         foreach ($config as $key => $value) {
             if (array_key_exists($key, $this->getConfigurationFields())) {
-                $this->$key = $value;
+                $accessor->setValue($this, $key, $value);
             }
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | No |
| New feature? | No |
| BC breaks? | No |
| Tests pass? | Yes |
| Scenarios pass? | - |
| Checkstyle issues? | No |
| Changelog updated? | No |
| Fixed tickets | - |
| Doc PR | - |

Configure a step element configuration value via its setter if it exists

 @BitOne This allows to configure things like https://github.com/akeneo/pim-community-dev/blob/master/src/Pim/Bundle/BaseConnectorBundle/Reader/File/YamlReader.php#L50 
