### PR TITLE
PIM-3446: Fix memory issue when loading a lot of warning

### DIFF
--- a/Entity/StepExecution.php
+++ b/Entity/StepExecution.php
@@ -143,8 +143,10 @@ class StepExecution
      *      targetEntity="Warning",
      *      mappedBy="stepExecution",
      *      cascade={"persist", "remove"},
+     *      fetch="EXTRA_LAZY",
      *      orphanRemoval=true
      * )
+     * @ORM\OrderBy({"id" = "ASC"})
      */
     private $warnings;
 


### PR DESCRIPTION
Fix associated with current upstream bug, for performance and memory issues.
http://doctrine-orm.readthedocs.org/en/latest/tutorials/extra-lazy-associations.html
