### PR TITLE
SQL errors on PostgreSQL due to reserved keyword

### DIFF
--- a/Entity/JobExecution.php
+++ b/Entity/JobExecution.php
@@ -62,7 +62,7 @@ class JobExecution
     /**
      * @var string|null The user who launched the job
      *
-     * @ORM\Column(name="user", type="string", nullable=true)
+     * @ORM\Column(name="`user`", type="string", nullable=true)
      */
     private $user;
 


### PR DESCRIPTION
- added quotes for "user" column definition
