### PR TITLE
[OPTIM] Update JobExecution entity regardless of the batch size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.3.x
+-----
+
+### Improvements
+
+ - Update JobExecution entity in the DB backend regardless of the batch size
+
 0.3.0
 ------------------
 

--- a/Entity/StepExecution.php
+++ b/Entity/StepExecution.php
@@ -363,6 +363,18 @@ class StepExecution
     }
 
     /**
+     * Return the difference in seconds between now and the startTime
+     *
+     * @return int
+     */
+    public function getCurrentExecutionTime()
+    {
+        $now = new \DateTime('now');
+        $diff = $now->diff($this->startTime);
+        return (int)$diff->format('%s');
+    }
+
+    /**
      * Returns the current status of this step
      *
      * @return BatchStatus the current status of this step

--- a/Step/ItemStep.php
+++ b/Step/ItemStep.php
@@ -205,9 +205,15 @@ class ItemStep extends AbstractStep
 
                 $itemsToWrite[] = $processedItem;
                 $writeCount++;
-                if (0 === $writeCount % $this->batchSize) {
+                if (0 === $writeCount % $this->batchSize)
+                {
                     $this->write($itemsToWrite);
                     $itemsToWrite = array();
+                    $this->getJobRepository()->updateStepExecution($stepExecution);
+
+                }
+                elseif (0 === ($stepExecution->getCurrentExecutionTime() % 10))
+                {
                     $this->getJobRepository()->updateStepExecution($stepExecution);
                 }
             }


### PR DESCRIPTION
This optimisation aims at strengthening the job execution itself.

The current implementation fails if x products take more than y seconds to be processed before they are effectively written. x is the batch size, y is usually the wait_timeout set on the database server side.

It can fail because the job statistics are updated by a separate SQL connexion which can idle for the whole batch size.

The optimisation consists in updating the JobExecution entity every 10 seconds, only if it's not updated when the item count is a multiple of the batch size.

| Q | A |
| --- | --- |
| Bug fix? | not really |
| New feature? | not really |
| BC breaks? | no since the default code is not altered ([if untouched oldcode] / [elseif with newcode]) |
| CI currently passes? |  |
| Tests pass? |  |
| Scenarios pass? |  |
| Checkstyle issues?* |  |
| PMD issues?** |  |
| Changelog updated? | yes |
| Fixed tickets |  |
| DB schema updated? | no |
| Migration script? | no |
| Doc PR | no |
