### PR TITLE
Add an optional parameter in StepExecution::incrementSummaryInfo

### DIFF
--- a/Entity/StepExecution.php
+++ b/Entity/StepExecution.php
@@ -565,14 +565,15 @@ class StepExecution
     /**
      * Increment counter in summary
      *
-     * @param string $key
+     * @param string  $key
+     * @param integer $increment
      */
-    public function incrementSummaryInfo($key)
+    public function incrementSummaryInfo($key, $increment = 1)
     {
         if (!isset($this->summary[$key])) {
-            $this->summary[$key]= 1;
+            $this->summary[$key]= $increment;
         } else {
-            $this->summary[$key]= $this->summary[$key] + 1;
+            $this->summary[$key]= $this->summary[$key] + $increment;
         }
     }
 

--- a/Tests/Unit/Entity/StepExecutionTest.php
+++ b/Tests/Unit/Entity/StepExecutionTest.php
@@ -258,6 +258,30 @@ class StepExecutionTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Test the increment by one (default case)
+     */
+    public function testIncrementSummaryInfoByOne()
+    {
+        $this->stepExecution->incrementSummaryInfo('create');
+        $this->stepExecution->incrementSummaryInfo('create');
+        $this->assertEquals($this->stepExecution->getSummaryInfo('create'), 2);
+        $this->stepExecution->incrementSummaryInfo('create');
+        $this->assertEquals($this->stepExecution->getSummaryInfo('create'), 3);
+    }
+
+    /**
+     * Test the increment by bulk
+     */
+    public function testIncrementSummaryInfoByBulk()
+    {
+        $this->stepExecution->incrementSummaryInfo('create');
+        $this->stepExecution->incrementSummaryInfo('create');
+        $this->assertEquals($this->stepExecution->getSummaryInfo('create'), 2);
+        $this->stepExecution->incrementSummaryInfo('create', 5);
+        $this->assertEquals($this->stepExecution->getSummaryInfo('create'), 7);
+    }
+
+    /**
      * Assert the entity tested
      *
      * @param object $entity


### PR DESCRIPTION
Allows to increment a counter by more than one

To clean this https://github.com/akeneo/pim-community-dev/pull/1911/files#diff-a08a5f55ee58ff0ed57cdeb9eca6d8e0R158
