### PR TITLE
PIM-3562: Added a UOW clear in BatchCommand

### DIFF
--- a/Command/BatchCommand.php
+++ b/Command/BatchCommand.php
@@ -104,6 +104,8 @@ class BatchCommand extends ContainerAwareCommand
             );
         }
 
+        $this->getDefaultEntityManager()->clear(get_class($jobInstance));
+
         $executionId = $input->getArgument('execution');
         if ($executionId) {
             $jobExecution = $this->getJobManager()->getRepository('AkeneoBatchBundle:JobExecution')->find($executionId);


### PR DESCRIPTION
The clear of UOW just after the job instance validation prevent the
temporary job instance configuration to be flushed in database during
import. (It's temporary because configuration is imported via command
line"