### PR TITLE
Add optional arguments in the constructor of InvalidItemException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.3.5
+-----
+
+### Features
+
+- Added optional arguments $code and $previous in the constructor of InvalidItemException
+
 0.3.4
 -----
 
@@ -11,7 +18,7 @@ CHANGELOG
 0.3.3
 -----
 
-### Bug fixes
+### Features
 
 - Add an optional parameter in StepExecution::incrementSummaryInfo
 

--- a/Item/InvalidItemException.php
+++ b/Item/InvalidItemException.php
@@ -20,13 +20,20 @@ class InvalidItemException extends \Exception
     /**
      * Constructor
      *
-     * @param string $message
-     * @param array  $item
-     * @param array  $messageParameters
+     * @param string     $message
+     * @param array      $item
+     * @param array      $messageParameters
+     * @param int        $code
+     * @param \Exception $previous
      */
-    public function __construct($message, array $item, array $messageParameters = array())
-    {
-        parent::__construct($message);
+    public function __construct(
+        $message,
+        array $item,
+        array $messageParameters = array(),
+        $code = 0,
+        \Exception $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
 
         $this->item              = $item;
         $this->messageParameters = $messageParameters;


### PR DESCRIPTION
To be able to know the previous exception when we skip an item with InvalidItemException