### PR TITLE
Add missing parameter

### DIFF
--- a/Job/DoctrineJobRepository.php
+++ b/Job/DoctrineJobRepository.php
@@ -36,7 +36,7 @@ class DoctrineJobRepository implements JobRepositoryInterface
      */
     public function __construct(
         EntityManager $entityManager,
-        $jobExecutionClass = 'Akeneo\\Bundle\\BatchBundle\\EntityJobExecution'
+        $jobExecutionClass = 'Akeneo\\Bundle\\BatchBundle\\Entity\\JobExecution'
     ) {
         $currentConn = $entityManager->getConnection();
 

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -12,6 +12,7 @@ parameters:
     akeneo_batch.launcher.simple_job_launcher.class:          Akeneo\Bundle\BatchBundle\Launcher\SimpleJobLauncher
     akeneo_batch.connectors_config:                           ~
     akeneo_batch.jobs_config:                                 ~
+    akeneo_batch.entity.job_execution.class:                  Akeneo\Bundle\BatchBundle\Entity\JobExecution
 
 services:
     # connectors registry


### PR DESCRIPTION
Fixes
```
PHP Fatal error:  Uncaught exception 'Symfony\Component\DependencyInjection\Exception\ParameterNotFoundException' with message 'The service "akeneo_batch.job_repository" has a dependency on a non-existent parameter "akeneo_batch.entity.job_execution.class". Did you mean this: "akeneo_batch.manager.job_execution.class"?'
```
was introduced in #62 
