### PR TITLE
PIM-5120: Do not hydrate all JobExecution of a JobInstance during a the creation of a JobExecution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 CHANGELOG
 =========
 
+0.3.8 (2015-09-03)
+------------------
+
+### Bug fixes
+
+- PIM-5120: Do not hydrate all JobExecution of a JobInstance during a the creation of a JobExecution
+
 0.3.7 (2015-09-03)
 ------------------
 

--- a/Entity/JobInstance.php
+++ b/Entity/JobInstance.php
@@ -346,9 +346,7 @@ class JobInstance
      */
     public function addJobExecution(JobExecution $jobExecution)
     {
-        if (!$this->jobExecutions->contains($jobExecution)) {
-            $this->jobExecutions->add($jobExecution);
-        }
+        $this->jobExecutions->add($jobExecution);
 
         return $this;
     }
@@ -360,9 +358,7 @@ class JobInstance
      */
     public function removeJobExecution(JobExecution $jobExecution)
     {
-        if ($this->jobExecutions->contains($jobExecution)) {
-            $this->jobExecutions->removeElement($jobExecution);
-        }
+        $this->jobExecutions->removeElement($jobExecution);
 
         return $this;
     }


### PR DESCRIPTION
| Q                 | A
| ----------------- | ---
| Specs             | -
| Behats            | -
| Blue CI           | running
| Changelog updated | Y 
| Review and 2 GTM  |
| Micro Demo (PO)   | -
| Migration script  | -
| Tech Doc          | -